### PR TITLE
verona-2.1.0-compliant playerConfig

### DIFF
--- a/docs/booklet-config.md
+++ b/docs/booklet-config.md
@@ -42,11 +42,24 @@ Ladeverhalten beim Start
   * "LAZY" (default): Start sobald wie möglich, Laden im Hintergrund fortsetzen
   * "EAGER": Testheft erst dann starten, wenn alle Inhalte geladen sind
 
-#### `log_mode`
+#### `logPolicy`
 Erfassen und Speichern von Log-Daten
-  * "OFF": Ausgeschaltet
-  * "LEAN": Nur wichtige Meldungen
-  * "RICH" (default): Alles
+  * "disabled": Ausgeschaltet
+  * "lean": Nur wichtige Meldungen
+  * "rich" (default): Alles außer debug-informationen
+  * "debug": Auch debug-informationen
+
+#### `pagingMode`
+pagingMode (https://verona-interfaces.github.io/player/#operation-publish-vopStartCommand)
+  * "separate" (default): pages are separated
+  * "concat-scroll": concat-scroll
+  * "concat-scroll-snap": concat-scroll-snap
+
+#### `stateReportPolicy`
+stateReportPolicy (https://verona-interfaces.github.io/player/#operation-publish-vopStartCommand)
+  * "none": pages are separated
+  * "eager" (default): concat-scroll
+  * "on-demand": concat-scroll-snap
 
 #### `page_navibuttons`
 Navigationsbuttons für die Seitennavigation (innerhalb einer Aufgabe)

--- a/src/app/config/booklet-config.json
+++ b/src/app/config/booklet-config.json
@@ -7,14 +7,33 @@
     },
     "defaultvalue": "LAZY"
   },
-  "log_mode": {
+  "logPolicy": {
     "label": "Erfassen und Speichern von Log-Daten",
     "options": {
-      "OFF": "Ausgeschaltet",
-      "LEAN": "Nur wichtige Meldungen",
-      "RICH": "Alles"
+      "disabled": "Ausgeschaltet",
+      "lean": "Nur wichtige Meldungen",
+      "rich": "Alles außer debug-informationen",
+      "debug": "Auch debug-informationen"
     },
-    "defaultvalue": "RICH"
+    "defaultvalue": "rich"
+  },
+  "pagingMode": {
+    "label": "pagingMode (https://verona-interfaces.github.io/player/#operation-publish-vopStartCommand)",
+    "options": {
+      "separate": "pages are separated",
+      "concat-scroll": "concat-scroll",
+      "concat-scroll-snap": "concat-scroll-snap"
+    },
+    "defaultvalue": "separate"
+  },
+  "stateReportPolicy": {
+    "label": "stateReportPolicy (https://verona-interfaces.github.io/player/#operation-publish-vopStartCommand)",
+    "options": {
+      "none": "pages are separated",
+      "eager": "concat-scroll",
+      "on-demand": "concat-scroll-snap"
+    },
+    "defaultvalue": "eager"
   },
   "page_navibuttons": {
     "label": "Navigationsbuttons für die Seitennavigation (innerhalb einer Aufgabe)",

--- a/src/app/config/booklet-config.ts
+++ b/src/app/config/booklet-config.ts
@@ -3,7 +3,9 @@ export class BookletConfig {
 	// do not change anything here directly!
 
 	loading_mode: "LAZY" | "EAGER" = "LAZY";
-	log_mode: "OFF" | "LEAN" | "RICH" = "RICH";
+	logPolicy: "disabled" | "lean" | "rich" | "debug" = "rich";
+	pagingMode: "separate" | "concat-scroll" | "concat-scroll-snap" = "separate";
+	stateReportPolicy: "none" | "eager" | "on-demand" = "eager";
 	page_navibuttons: "OFF" | "MERGED" | "SEPARATE_TOP" | "SEPARATE_BOTTOM" = "SEPARATE_BOTTOM";
 	unit_navibuttons: "OFF" | "ARROWS_ONLY" | "FULL" = "FULL";
 	unit_menu: "OFF" | "ENABLED_ONLY" | "FULL" = "OFF";
@@ -16,7 +18,9 @@ export class BookletConfig {
 	public setFromKeyValuePairs(config) {
 		if (config) {
 			if (config['loading_mode']) { this.loading_mode = config['loading_mode']}
-			if (config['log_mode']) { this.log_mode = config['log_mode']}
+			if (config['logPolicy']) { this.logPolicy = config['logPolicy']}
+			if (config['pagingMode']) { this.pagingMode = config['pagingMode']}
+			if (config['stateReportPolicy']) { this.stateReportPolicy = config['stateReportPolicy']}
 			if (config['page_navibuttons']) { this.page_navibuttons = config['page_navibuttons']}
 			if (config['unit_navibuttons']) { this.unit_navibuttons = config['unit_navibuttons']}
 			if (config['unit_menu']) { this.unit_menu = config['unit_menu']}
@@ -38,8 +42,14 @@ export class BookletConfig {
 					case 'loading_mode':
 						this.loading_mode = configValue;
 						break;
-					case 'log_mode':
-						this.log_mode = configValue;
+					case 'logPolicy':
+						this.logPolicy = configValue;
+						break;
+					case 'pagingMode':
+						this.pagingMode = configValue;
+						break;
+					case 'stateReportPolicy':
+						this.stateReportPolicy = configValue;
 						break;
 					case 'page_navibuttons':
 						this.page_navibuttons = configValue;

--- a/src/app/test-controller/unithost/unithost.component.ts
+++ b/src/app/test-controller/unithost/unithost.component.ts
@@ -83,7 +83,13 @@ export class UnithostComponent implements OnInit, OnDestroy {
                     dataParts: pendingUnitDataToRestore
                   },
                   playerConfig: {
-                    logPolicy: 'eager' // 'debug'
+                    logPolicy: this.tcs.bookletConfig.logPolicy,
+                    unitNumber: this.myUnitSequenceId,
+                    unitTitle: this.unitTitle,
+                    unitId: this.myUnitDbKey,
+                    unitCount: this.tcs.maxUnitSequenceId,
+                    stateReportPolicy: this.tcs.bookletConfig.stateReportPolicy,
+                    pagingMode: this.tcs.bookletConfig.pagingMode
                   }
                 }, '*');
               }


### PR DESCRIPTION
MM, bitte guck noch mal ob das in deinem Sinne, bevor wir es in den Master ziehen.

---

As in verona-player-interface- 2.1.0 requested, the `playerConfig` in `vopReadyNotification` now

* includes `pagingMode`, `stateReportPolicy` and `logPolicy` from bookletConfig

* includes `unitNumber`, `unitTitle`, `unitId`

* it includes also `unitCount`, which is not part of the verona-2.1.0-interface, but proposed here: https://github.com/verona-interfaces/player/issues/24